### PR TITLE
Update MarketingModule.Core version and fix item count

### DIFF
--- a/src/VirtoCommerce.MarketingExperienceApi.Data/Queries/EvaluateDynamicContentQueryHandler.cs
+++ b/src/VirtoCommerce.MarketingExperienceApi.Data/Queries/EvaluateDynamicContentQueryHandler.cs
@@ -32,7 +32,7 @@ namespace VirtoCommerce.MarketingExperienceApi.Data.Queries
 
             var items = await _marketingDynamicContentEvaluator.EvaluateItemsAsync(context);
 
-            var result = new EvaluateDynamicContentResult() { Items = items, TotalCount = items.Length };
+            var result = new EvaluateDynamicContentResult() { Items = items, TotalCount = items.Count };
             return result;
         }
     }

--- a/src/VirtoCommerce.MarketingExperienceApi.Data/VirtoCommerce.MarketingExperienceApi.Data.csproj
+++ b/src/VirtoCommerce.MarketingExperienceApi.Data/VirtoCommerce.MarketingExperienceApi.Data.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.817.0" />
-    <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.812.0" />
+    <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.823.0" />
     <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.861.0" />
     <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.904.0" />
   </ItemGroup>

--- a/src/VirtoCommerce.MarketingExperienceApi.Web/module.manifest
+++ b/src/VirtoCommerce.MarketingExperienceApi.Web/module.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <id>VirtoCommerce.MarketingExperienceApi</id>
-  <version>3.903.0</version>
+  <version>3.902.0</version>
   <version-tag />
 
   <platformVersion>3.861.0</platformVersion>

--- a/src/VirtoCommerce.MarketingExperienceApi.Web/module.manifest
+++ b/src/VirtoCommerce.MarketingExperienceApi.Web/module.manifest
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <id>VirtoCommerce.MarketingExperienceApi</id>
-  <version>3.902.0</version>
+  <version>3.903.0</version>
   <version-tag />
 
   <platformVersion>3.861.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Customer" version="3.817.0" />
-    <dependency id="VirtoCommerce.Marketing" version="3.812.0" />
+    <dependency id="VirtoCommerce.Marketing" version="3.823.0" />
     <dependency id="VirtoCommerce.Xapi" version="3.904.0" />
   </dependencies>
 


### PR DESCRIPTION
Upgraded VirtoCommerce.MarketingModule.Core dependency to 3.823.0 and updated module manifest accordingly. Fixed EvaluateDynamicContentResult to use items.Count instead of items.Length for TotalCount.

## Description

## References
### QA-test:
### Jira-link:
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fix total count calculation for evaluated dynamic content and upgrade Marketing module dependencies/manifest versions.
> 
> - **Data/API**:
>   - Fix `EvaluateDynamicContentQueryHandler` to set `EvaluateDynamicContentResult.TotalCount` using `items.Count` instead of `items.Length`.
> - **Dependencies/Manifest**:
>   - Bump `VirtoCommerce.MarketingModule.Core` to `3.823.0` in `VirtoCommerce.MarketingExperienceApi.Data.csproj`.
>   - Update `module.manifest`: module version to `3.903.0` and `VirtoCommerce.Marketing` dependency to `3.823.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa9358bc1ea96da944180e128edc6b5c4c744aa7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->