### PR TITLE
Update MarketingModule.Core version and fix item count (#12)

### DIFF
--- a/src/VirtoCommerce.MarketingExperienceApi.Data/Queries/EvaluateDynamicContentQueryHandler.cs
+++ b/src/VirtoCommerce.MarketingExperienceApi.Data/Queries/EvaluateDynamicContentQueryHandler.cs
@@ -32,7 +32,7 @@ namespace VirtoCommerce.MarketingExperienceApi.Data.Queries
 
             var items = await _marketingDynamicContentEvaluator.EvaluateItemsAsync(context);
 
-            var result = new EvaluateDynamicContentResult() { Items = items, TotalCount = items.Length };
+            var result = new EvaluateDynamicContentResult() { Items = items, TotalCount = items.Count };
             return result;
         }
     }

--- a/src/VirtoCommerce.MarketingExperienceApi.Data/VirtoCommerce.MarketingExperienceApi.Data.csproj
+++ b/src/VirtoCommerce.MarketingExperienceApi.Data/VirtoCommerce.MarketingExperienceApi.Data.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.817.0" />
-    <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.812.0" />
+    <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.823.0" />
     <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.861.0" />
     <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.904.0" />
   </ItemGroup>

--- a/src/VirtoCommerce.MarketingExperienceApi.Web/module.manifest
+++ b/src/VirtoCommerce.MarketingExperienceApi.Web/module.manifest
@@ -7,7 +7,7 @@
   <platformVersion>3.861.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Customer" version="3.817.0" />
-    <dependency id="VirtoCommerce.Marketing" version="3.812.0" />
+    <dependency id="VirtoCommerce.Marketing" version="3.823.0" />
     <dependency id="VirtoCommerce.Xapi" version="3.904.0" />
   </dependencies>
 


### PR DESCRIPTION
## Description
Upgraded VirtoCommerce.MarketingModule.Core dependency to 3.823.0 and updated module manifest accordingly. Fixed EvaluateDynamicContentResult to use items.Count instead of items.Length for TotalCount.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4614
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.MarketingExperienceApi_3.902.0-pr-13-c42c.zip