### PR TITLE
VCST-4328: Update to .NET10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <!-- These properties will be shared for all projects -->
   <PropertyGroup>
-    <VersionPrefix>3.903.0</VersionPrefix>
+    <VersionPrefix>3.1000.0</VersionPrefix>
     <VersionSuffix>
     </VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(BuildNumber)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
@@ -10,4 +10,7 @@
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+  <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-rvv3-g6hj-g44x" />
+  </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.MarketingExperienceApi.Core/VirtoCommerce.MarketingExperienceApi.Core.csproj
+++ b/src/VirtoCommerce.MarketingExperienceApi.Core/VirtoCommerce.MarketingExperienceApi.Core.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.MarketingExperienceApi.Data/Schemas/DynamicContentItemType.cs
+++ b/src/VirtoCommerce.MarketingExperienceApi.Data/Schemas/DynamicContentItemType.cs
@@ -1,7 +1,6 @@
 using GraphQL.Types;
 using VirtoCommerce.MarketingModule.Core.Model;
 using VirtoCommerce.Xapi.Core.Extensions;
-using VirtoCommerce.Xapi.Core.Helpers;
 using VirtoCommerce.Xapi.Core.Schemas;
 using VirtoCommerce.Xapi.Core.Services;
 
@@ -20,7 +19,7 @@ namespace VirtoCommerce.MarketingExperienceApi.Data.Schemas
             ExtendableFieldAsync<ListGraphType<DynamicPropertyValueType>>(
             "dynamicProperties",
             "Dynamic content dynamic property values",
-                QueryArgumentPresets.GetArgumentForDynamicProperties(),
+                null,
                 async context => await dynamicPropertyResolverService.LoadDynamicPropertyValues(context.Source, context.GetArgumentOrValue<string>("cultureName")));
         }
     }

--- a/src/VirtoCommerce.MarketingExperienceApi.Data/VirtoCommerce.MarketingExperienceApi.Data.csproj
+++ b/src/VirtoCommerce.MarketingExperienceApi.Data/VirtoCommerce.MarketingExperienceApi.Data.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.817.0" />
-    <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.823.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.861.0" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.904.0" />
+    
+    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1000.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.MarketingExperienceApi.Web/VirtoCommerce.MarketingExperienceApi.Web.csproj
+++ b/src/VirtoCommerce.MarketingExperienceApi.Web/VirtoCommerce.MarketingExperienceApi.Web.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/VirtoCommerce.MarketingExperienceApi.Web/module.manifest
+++ b/src/VirtoCommerce.MarketingExperienceApi.Web/module.manifest
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <id>VirtoCommerce.MarketingExperienceApi</id>
-  <version>3.903.0</version>
+  <version>3.1000.0</version>
   <version-tag />
 
-  <platformVersion>3.861.0</platformVersion>
+  <platformVersion>3.1002.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Customer" version="3.817.0" />
-    <dependency id="VirtoCommerce.Marketing" version="3.823.0" />
-    <dependency id="VirtoCommerce.Xapi" version="3.904.0" />
+    <dependency id="VirtoCommerce.Customer" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Marketing" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Xapi" version="3.1000.0" />
   </dependencies>
 
   <title>Marketing Experience API</title>
@@ -23,7 +23,7 @@
   <iconUrl>Modules/$(VirtoCommerce.MarketingExperienceApi)/Content/logo.png</iconUrl>
   <requireLicenseAcceptance>false</requireLicenseAcceptance>
   <releaseNotes>First version.</releaseNotes>
-  <copyright>Copyright © 2011-2025 Virto Commerce. All rights reserved</copyright>
+  <copyright>Copyright © 2024-2026 Virto Commerce. All rights reserved</copyright>
   <tags>extension module</tags>
   <assemblyFile>VirtoCommerce.MarketingExperienceApi.Web.dll</assemblyFile>
   <moduleType>VirtoCommerce.MarketingExperienceApi.Web.Module, VirtoCommerce.MarketingExperienceApi.Web</moduleType>

--- a/tests/VirtoCommerce.MarketingExperienceApi.Tests/VirtoCommerce.MarketingExperienceApi.Tests.csproj
+++ b/tests/VirtoCommerce.MarketingExperienceApi.Tests/VirtoCommerce.MarketingExperienceApi.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup>
@@ -8,13 +8,13 @@
     <SonarQubeTestProject>true</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\VirtoCommerce.MarketingExperienceApi.Data\VirtoCommerce.MarketingExperienceApi.Data.csproj" />


### PR DESCRIPTION
## Description
Update to .NET10

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4328
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.MarketingExperienceApi_3.1000.0-pr-15-bcc0.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to a major runtime/framework upgrade (`net8.0` -> `net10.0`) and broad dependency/version bumps that can introduce build or runtime compatibility issues.
> 
> **Overview**
> Upgrades the module to **.NET 10** by switching all projects (including tests) from `net8.0` to `net10.0` and bumping the module/package version to `3.1000.0`.
> 
> Aligns VirtoCommerce dependencies and `module.manifest` requirements to the `3.1000.x` line (including `Platform` `3.1002.0`), updates the test stack to `xunit.v3`/newer SDKs, and adds a `NuGetAuditSuppress` entry for `GHSA-rvv3-g6hj-g44x`.
> 
> Adjusts the GraphQL `dynamicProperties` field in `DynamicContentItemType` to no longer supply `QueryArgumentPresets.GetArgumentForDynamicProperties()` (passing `null` instead), reflecting an API/signature change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcc0dc364f189587f0bd646c0f2193e1102e7484. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->