### PR TITLE
[VCST-5022] Apply sort argument in promotionCoupons resolver

### DIFF
--- a/src/VirtoCommerce.MarketingExperienceApi.Data/Queries/PromotionCouponsQueryHandler.cs
+++ b/src/VirtoCommerce.MarketingExperienceApi.Data/Queries/PromotionCouponsQueryHandler.cs
@@ -33,6 +33,7 @@ public class PromotionCouponsQueryHandler : IQueryHandler<PromotionCouponsQuery,
         promotionSearchCriteria.CouponCount = 1;
         promotionSearchCriteria.Skip = request.Skip;
         promotionSearchCriteria.Take = request.Take;
+        promotionSearchCriteria.Sort = request.Sort;
 
         return promotionSearchCriteria;
     }

--- a/tests/VirtoCommerce.MarketingExperienceApi.Tests/PromotionCouponsQueryHandlerTests.cs
+++ b/tests/VirtoCommerce.MarketingExperienceApi.Tests/PromotionCouponsQueryHandlerTests.cs
@@ -1,0 +1,56 @@
+using System.Threading;
+using System.Threading.Tasks;
+using VirtoCommerce.MarketingExperienceApi.Data.Queries;
+using VirtoCommerce.MarketingModule.Core.Model.Promotions;
+using VirtoCommerce.MarketingModule.Core.Model.Promotions.Search;
+using VirtoCommerce.MarketingModule.Core.Search;
+using Xunit;
+
+namespace VirtoCommerce.MarketingExperienceApi.Tests;
+
+[Trait("Category", "Unit")]
+public class PromotionCouponsQueryHandlerTests
+{
+    // Hand-written fake (no Moq dependency in this test project) that captures the
+    // PromotionSearchCriteria the handler builds. SearchNoCloneAsync(criteria) delegates
+    // to ISearchService<,,>.SearchAsync(criteria, clone: false), so capturing there is
+    // equivalent to capturing what the handler passes to SearchNoCloneAsync.
+    private sealed class CapturingPromotionSearchService : IPromotionSearchService
+    {
+        public PromotionSearchCriteria CapturedCriteria { get; private set; }
+
+        public Task<PromotionSearchResult> SearchAsync(PromotionSearchCriteria criteria, bool clone = true)
+        {
+            CapturedCriteria = criteria;
+            return Task.FromResult(new PromotionSearchResult());
+        }
+
+        public Task<PromotionSearchResult> SearchPromotionsAsync(PromotionSearchCriteria criteria)
+        {
+            CapturedCriteria = criteria;
+            return Task.FromResult(new PromotionSearchResult());
+        }
+    }
+
+    [Fact]
+    public async Task Handle_PassesSortArgumentOntoSearchCriteria()
+    {
+        // Arrange
+        var service = new CapturingPromotionSearchService();
+        var handler = new PromotionCouponsQueryHandler(service);
+        var query = new PromotionCouponsQuery
+        {
+            StoreId = "TestStore",
+            Sort = "endDate:asc",
+            Skip = 0,
+            Take = 20,
+        };
+
+        // Act
+        await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(service.CapturedCriteria);
+        Assert.Equal("endDate:asc", service.CapturedCriteria.Sort);
+    }
+}


### PR DESCRIPTION
## Root cause
The xAPI `promotionCoupons` query advertises `sort: String` in its schema (inherited from the base `SearchQuery`, parsed into `request.Sort` in `Map`), but `PromotionCouponsQueryHandler.GetPromotionSearchCriteria()` mapped `Store`/`Skip`/`Take` onto the `PromotionSearchCriteria` and **never assigned `.Sort`**. The argument was accepted and silently dropped, so every `sort` value returned identical (insertion) order — a silent contract violation (VCST-5022).

## Fix (one line, non-breaking)
```csharp
promotionSearchCriteria.Sort = request.Sort;
```
in `src/VirtoCommerce.MarketingExperienceApi.Data/Queries/PromotionCouponsQueryHandler.cs`. `PromotionSearchCriteria.Sort` is the standard `SearchCriteriaBase.Sort` the search service honors. When `sort` is null/empty, default ordering is unchanged — this restores the already-advertised contract, it does not change any public REST/GraphQL/DTO/schema, DB/migration, domain event, or manifest.

## Test added
`tests/VirtoCommerce.MarketingExperienceApi.Tests/PromotionCouponsQueryHandlerTests.cs` — a hand-written `IPromotionSearchService` fake (no Moq dependency added) captures the criteria the handler builds and asserts `criteria.Sort == "endDate:asc"` after `Handle(...)`.
**Red → green:** before fix `Failed 1 / Passed 1` (`Sort` was null); after fix `Passed 2 / Failed 0`. Pre-existing test unmodified. Full solution build clean.

## Out of scope (deferred)
The ticket's secondary ask — *erroring* on invalid `sort` fields (`errors[]` for `doesnotexist:asc` etc.) — is a separate validation enhancement and is **not** addressed here, to keep this fix minimal.

JIRA: https://virtocommerce.atlassian.net/browse/VCST-5022

---
**🛑 DO NOT MERGE until human review + QA E2E (needs deploy verification).** Opened by the `/qa-fix` auto-fix pipeline; the live symptom requires a redeployed alpha artifact to verify on QA.
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.MarketingExperienceApi_3.1002.0-pr-16-3e3b.zip